### PR TITLE
Revert "Bump JetBrains.ReSharper.CommandLineTools from 2020.2.2 to 2020.2.3"

### DIFF
--- a/_build.csproj
+++ b/_build.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="JetBrains.ReSharper.CommandLineTools" Version="2020.2.3">
+		<PackageReference Include="JetBrains.ReSharper.CommandLineTools" Version="2020.2.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
R# seems to have problems with cache

```00:01:00 Updating caches...
  00:02:00 Updating caches...
  00:03:00 Updating caches...
  00:04:00 Updating caches...
  00:05:00 Updating caches...
```